### PR TITLE
Coreos refinements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN mv /etc/sd-agent/conf.d/docker_daemon.yaml.example /etc/sd-agent/conf.d/dock
  && sed -i 's/# collect_images_stats: false/collect_images_stats: true/g' /etc/sd-agent/conf.d/docker_daemon.yaml \
  && sed -i 's/# collect_image_size: false/collect_image_size: true/g' /etc/sd-agent/conf.d/docker_daemon.yaml \
  && sed -i 's/# collect_disk_stats: true/collect_disk_stats: true/g' /etc/sd-agent/conf.d/docker_daemon.yaml \
+ && sed -i 's/# timeout: 10/timeout: 10/g' /etc/sd-agent/conf.d/docker_daemon.yaml \
  && service sd-agent restart 
 
 COPY entrypoint.sh /entrypoint.sh

--- a/sd-agent.service
+++ b/sd-agent.service
@@ -8,7 +8,8 @@ Restart=always
 EnvironmentFile=/etc/os-release
 ExecStartPre=-/usr/bin/docker stop sd-agent
 ExecStartPre=-/usr/bin/docker rm -f sd-agent
-ExecStartPre=/usr/bin/docker pull serverdensity/sd-agent
+ExecStartPre=-/usr/bin/docker rmi sd-agent:latest
+ExecStartPre=/usr/bin/docker pull serverdensity/sd-agent:latest
 TimeoutStartSec=0
 ExecStartPre=-/usr/bin/docker kill sd-agent
 ExecStartPre=-/usr/bin/docker rm sd-agent
@@ -20,7 +21,7 @@ ExecStart= /bin/bash -c "docker run --name sd-agent \
     -e AGENT_KEY=`etcdctl get /serverdensity/agent_key/%H` \
     -e ACCOUNT=`etcdctl get /serverdensity/ACCOUNT` \
     -e SD_HOSTNAME=%H \
-    serverdensity/sd-agent"
+    serverdensity/sd-agent:latest"
 ExecStop=/usr/bin/docker stop sd-agent
 
 [X-Fleet]


### PR DESCRIPTION
Increases the docker_daemon timeout to 10s, from 5 seconds. Also improves the example coreos service file to ensure that the latest image is uses. 