### PR TITLE
Update docs examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,25 @@ The above example will make the port available on the host only. If you want the
 ```
 
 ## Enabling Plugins
-### Official Plugins
+### Official Plugins - Using sd-agent as a Base Image
+You can enable official plugins by creating a Dockerfile, using `serverdensity/sd-agent:latest` as a base image, and installing the plugin and copying the config to the container.
+
+For example:
+```
+FROM serverdensity/sd-agent
+
+# Install the MySQL plugin
+RUN apt-get update && apt-get install sd-agent-mysql -y
+# Add MySQL check configuration
+ADD mysql.yaml /etc/sd-agent/conf.d/mysql.yaml
+
+# Cleanup apt
+RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+```
+Please see the examples directory for more examples.
+
+
+### Official Plugins - Using mounted volumes
 You can enable official plugins by mounting the conf.d & checks.d folders which will be copied to the correct locations for the agent when the container starts. Checks and config files can be found at the [sd-agent-core-plugins repo](https://github.com/serverdensity/sd-agent-core-plugins).
 
 The example below is for MySQL, however any plugin can be used.
@@ -130,7 +148,25 @@ The example below is for MySQL, however any plugin can be used.
 
 Now when the container starts the checks and their configs will be copied to the correct directories.
 
-### Custom plugins - v2 (Preferred)
+### Custom plugins - v2 (Preferred) - Using sd-agent as a Base Image
+You can enable official plugins by creating a Dockerfile, using `serverdensity/sd-agent:latest` as a base image, and copying the plugin and config to the container.
+
+1. Create a custom plugin as per the [Information about Custom Plugins - v2](https://support.serverdensity.com/hc/en-us/articles/115014887548) document.
+
+2. Create a Dockerfile using `serverdensity/sd-agent:latest` as a base image, copying the plugin and config to the container
+```
+FROM serverdensity/sd-agent
+
+# Add Custom check configuration
+ADD custom.yaml /etc/sd-agent/conf.d/custom.yaml
+
+# Add Custom check code
+ADD custom.py /usr/share/python/sd-agent/checks.d/custom.py
+```
+Please see the examples directory for more examples.
+
+
+### Custom plugins - v2 (Preferred) - Using mounted volumes
 1. Create a custom plugin as per the [Information about Custom Plugins - v2](https://support.serverdensity.com/hc/en-us/articles/115014887548) document.
 
 2. Create a configuration directory (if you're using official plugins too you may already have this) and copy your custom plugin `conf.yaml` files to the new directory:
@@ -168,6 +204,9 @@ Now when the container starts the checks and their configs will be copied to the
 Now when the container starts your v2 custom plugins will be copied to the correct directories for the agent.
 
 ### Custom plugins - v1 (Legacy)
+
+| WARNING: This method will soon be deprecated. If you have v1 custom plugins, we recommend converting them to [v2 Custom plugins instead](https://support.serverdensity.com/hc/en-us/articles/360001082746) |
+| --- |
 1. Create a plugins directory and copy your `check.py` files to the new directory:
 
     ```

--- a/examples/custom_plugin/Dockerfile
+++ b/examples/custom_plugin/Dockerfile
@@ -1,0 +1,7 @@
+FROM serverdensity/sd-agent
+
+# Add Custom plugin configuration (portmon)
+ADD portmon.yaml /etc/sd-agent/conf.d/portmon.yaml
+
+# Add Custom plugin check (portmon)
+ADD portmon.py /usr/share/python/sd-agent/checks.d/portmon.py

--- a/examples/custom_plugin/mysql.yaml
+++ b/examples/custom_plugin/mysql.yaml
@@ -1,0 +1,10 @@
+init_config:
+  timeout: 10
+instances:
+  - server: example.com
+  - server: 8.8.8.8
+    port: 53
+    timeout: 100
+    tags:
+      - dns
+      - google

--- a/examples/custom_plugin/portmon.py
+++ b/examples/custom_plugin/portmon.py
@@ -1,0 +1,64 @@
+import time
+import socket
+
+from checks import AgentCheck
+
+
+class PortMon(AgentCheck):
+    def check(self, instance):
+        # Load default_timeout value from the init_config, if not present default to 5
+        default_timeout = self.init_config.get('default_timeout', 5)
+        # Load port value from the instance config
+        port = instance.get('port', 80)
+        # Attempt to load the timeout from the instance config. If not present fallback to default_timeout
+        timeout = float(instance.get('timeout', default_timeout))
+        # If we don't find a server for this instance stop the check now
+        if 'server' not in instance:
+            # Output to the info log that we're skipping this instance due to no server being configured
+            self.log.info("Skipping instance, no server found.")
+            return
+        server = instance['server']
+        # Attempt to load the tags from the instance config. If not present fallback to an empty list
+        tags = instance.get('tags', [])
+        # Append the tag 'server: server:port' to the tags list, based on the values loaded from the instance config.
+        tags.append("server: {}:{}".format(server,port))
+        # A handy debug line in case we need to output information for troubleshooting
+        self.log.debug("Timeout set to {} for {}:{} with tags: {}".format(timeout, server, port, tags))
+
+        # Begin the check by creating a socket
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        # Set the timeout on the socket to the configured timeout
+        s.settimeout(timeout)
+        # Get the current time so we can calculate the response time
+        t_init = time.time()
+        # Attempt the following unless an error is seen
+        try:
+            # Set status to 1, so we can report back a simple status metric
+            status = 1
+            # Attempt to connect to a remote socket at server, port
+            s.connect((server, port))
+            # Measure the response time from the timestamp we took earlier in the check
+            response_time = time.time() - t_init
+            # Close the socket
+            s.close()
+        # If we see a socket error or a socket timeout
+        except (socket.error, socket.timeout):
+            # As this is an error condition we'll set the response time to '-1'
+            # so that it's obvious the connection failed when viewing graphs
+            response_time =  -1
+            # We'll also set the status to 0 as this is an error
+            status = 0
+        # Set the portmon.response.time metric, along with the tags we set earlier
+        self.gauge('portmon.reponse.time', response_time, tags=tags)
+        # Set the portmon.response.status metric, along with the tags we set earlier
+        self.gauge('portmon.reponse.status', status, tags=tags)
+        # The check is complete.
+        # Once all instances have completed checks the results will be sent to Server Density!
+
+if __name__ == '__main__':
+    # Load the check and instance configurations
+    check, instances = PortMon.from_yaml('/etc/sd-agent/conf.d/portmon.yaml')
+    for instance in instances:
+        print "\nRunning the check against host: {}:{}".format(instance['server'],instance.get('port', 80))
+        check.check(instance)
+        print 'Metrics: {}'.format(check.get_metrics())

--- a/examples/docker-compose/docker-compose.yaml
+++ b/examples/docker-compose/docker-compose.yaml
@@ -1,0 +1,21 @@
+version: '3'
+services:
+  nginx:
+    build:
+      context: nginx
+    ports:
+      - 80:80
+  mon:
+    build:
+      context: mon
+    environment:
+      - AGENT_KEY=
+      - ACCOUNT=
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /proc/:/host/proc/:ro
+      - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
+    depends_on:
+      - nginx
+    pid: "host"
+

--- a/examples/docker-compose/mon/Dockerfile
+++ b/examples/docker-compose/mon/Dockerfile
@@ -1,0 +1,3 @@
+FROM serverdensity/sd-agent:latest
+RUN apt-get update && apt-get install sd-agent-nginx -y
+ADD nginx.yaml /etc/sd-agent/conf.d/nginx.yaml

--- a/examples/docker-compose/mon/nginx.yaml
+++ b/examples/docker-compose/mon/nginx.yaml
@@ -1,0 +1,4 @@
+init_config:
+
+instances:
+  - nginx_status_url: http://nginx:8080/nginx_status/

--- a/examples/docker-compose/nginx/Dockerfile
+++ b/examples/docker-compose/nginx/Dockerfile
@@ -1,0 +1,6 @@
+FROM nginx:1.15.1
+RUN rm /etc/nginx/nginx.conf
+COPY nginx.conf /etc/nginx/
+RUN rm /etc/nginx/conf.d/default.conf
+COPY example.com.conf /etc/nginx/conf.d/
+COPY index.html /var/www/index.html

--- a/examples/docker-compose/nginx/example.com.conf
+++ b/examples/docker-compose/nginx/example.com.conf
@@ -1,0 +1,22 @@
+server {
+    listen 80 default_server;
+    server_name example.com;
+
+    root /var/www/;
+    index index.html;
+
+    location / {
+        root   /var/www;
+        index  index.html index.htm;
+    }
+
+}
+
+server {
+        listen 8080;
+        server_name example.com;
+        location /nginx_status {
+                stub_status on;
+                access_log off;
+        }
+   }

--- a/examples/docker-compose/nginx/index.html
+++ b/examples/docker-compose/nginx/index.html
@@ -1,0 +1,1 @@
+<html><body><h1>It works!</h1></body></html>

--- a/examples/docker-compose/nginx/nginx.conf
+++ b/examples/docker-compose/nginx/nginx.conf
@@ -1,0 +1,55 @@
+# Define the user that will own and run the Nginx server
+user  nginx;
+
+# Define the number of worker processes; recommended value is the number of
+# cores that are being used by your server
+worker_processes  1;
+
+# Define the location on the file system of the error log, plus the minimum
+# severity to log messages for
+error_log  /var/log/nginx/error.log warn;
+
+# Define the file that will store the process ID of the main NGINX process
+pid        /var/run/nginx.pid;
+
+
+# events block defines the parameters that affect connection processing.
+events {
+    # Define the maximum number of simultaneous connections that can be opened by a worker process
+    worker_connections  1024;
+}
+
+
+# http block defines the parameters for how NGINX should handle HTTP web traffic
+http {
+    # Include the file defining the list of file types that are supported by NGINX
+    include       /etc/nginx/mime.types;
+
+    # Define the default file type that is returned to the user
+    default_type  text/html;
+
+    # Define the format of log messages.
+    log_format main '$remote_addr - $remote_user [$time_local] '
+                             '"$request" $status $body_bytes_sent '
+                             '"$http_referer" "$http_user_agent"'
+                             'rt=$request_time uct="$upstream_connect_time" uht="$upstream_header_time" urt="$upstream_response_time"';
+
+
+    # Define the location of the log of access attempts to NGINX
+    access_log  /var/log/nginx/access.log  main;
+
+    # Define the parameters to optimize the delivery of static content
+    sendfile        on;
+    tcp_nopush     on;
+    tcp_nodelay    on;
+
+    # Define the timeout value for keep-alive connections with the client
+    keepalive_timeout  65;
+
+    # Define the usage of the gzip compression algorithm to reduce the amount of data to transmit
+    gzip  on;
+
+    proxy_read_timeout 3600;
+    # Include additional parameters for virtual host(s)/server(s)
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/examples/mysql/Dockerfile
+++ b/examples/mysql/Dockerfile
@@ -1,0 +1,9 @@
+FROM serverdensity/sd-agent
+
+# Install the MySQL plugin
+RUN apt-get update && apt-get install sd-agent-mysql -y
+# Add MySQL check configuration
+ADD mysql.yaml /etc/sd-agent/conf.d/mysql.yaml
+
+# Cleanup apt
+RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/examples/mysql/mysql.yaml
+++ b/examples/mysql/mysql.yaml
@@ -1,0 +1,15 @@
+init_config:
+
+instances:
+  - server: 172.17.42.1
+    user: serverdensity
+    pass: supersecretpassword
+    tags:
+        - docker_container
+    options:
+        galera_cluster: false
+        extra_status_metrics: true
+        extra_innodb_metrics: true
+        extra_performance_metrics: true
+        schema_size_metrics: false
+        disable_innodb_metrics: false

--- a/examples/mysql_nginx/Dockerfile
+++ b/examples/mysql_nginx/Dockerfile
@@ -1,0 +1,11 @@
+FROM serverdensity/sd-agent
+
+# Install the MySQL & nginx plugins
+RUN apt-get update && apt-get install sd-agent-mysql sd-agent-nginx -y
+# Add MySQL check configuration
+ADD mysql.yaml /etc/sd-agent/conf.d/mysql.yaml
+# Add nginx check configuration
+ADD nginx.yaml /etc/sd-agent/conf.d/nginx.yaml
+
+# Cleanup apt
+RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/examples/mysql_nginx/mysql.yaml
+++ b/examples/mysql_nginx/mysql.yaml
@@ -1,0 +1,15 @@
+init_config:
+
+instances:
+  - server: 172.17.42.1
+    user: serverdensity
+    pass: supersecretpassword
+    tags:
+        - docker_container
+    options:
+        galera_cluster: false
+        extra_status_metrics: true
+        extra_innodb_metrics: true
+        extra_performance_metrics: true
+        schema_size_metrics: false
+        disable_innodb_metrics: false

--- a/examples/mysql_nginx/nginx.yaml
+++ b/examples/mysql_nginx/nginx.yaml
@@ -1,0 +1,6 @@
+init_config:
+
+instances:
+  - nginx_status_url: http://172.17.42.1/nginx_status/
+     tags:
+       - instance:foo


### PR DESCRIPTION
Adds instructions to allow you to install plugins using the official container as a base image. 
Adds examples for the above, along with a more complex docker-compose example. 

@NassimHC please can you review and merge if happy? 

The Readme over at Docker Hub will need to be updated once this has been merged. 